### PR TITLE
Updated for lower versions of Android

### DIFF
--- a/www/config.xml
+++ b/www/config.xml
@@ -4,12 +4,12 @@
 <widget xmlns     = "http://www.w3.org/ns/widgets"
         xmlns:gap = "http://phonegap.com/ns/1.0"
         id        = "com.phonegap.hello-world"
-        version   = "1.0.4">
+        version   = "1.0.0">
 
-    <name>My App</name>
+    <name>Hello World</name>
 
     <description>
-        This is my new app
+        Hello World sample application that responds to the deviceready event.
     </description>
 
     <author href="http://phonegap.com" email="support@phonegap.com">


### PR DESCRIPTION
I am new to Android development and I expected the phonegap-start to work with Android 2.2 and on my phone.  I received an error parsing the file, but it was hard to trace back to the minimum sdk version being set to 14 instead of 7 which is listed as the phonegap default here:  https://build.phonegap.com/docs/config-xml  ; "minSdkVersion defaults to 7 (Android 2.1); maxSdkVersion is unset by default"  

It makes sense to me that the beginner phonegap program should match the documentation in the same section in order to facilitate beginners getting started with phonegap build.
