### PR TITLE
Improving the comments for the app icon setting.

### DIFF
--- a/www/config.xml
+++ b/www/config.xml
@@ -68,7 +68,9 @@
         <gap:plugin name="com.phonegap.plugins.barcodescanner" />
     -->
 
-    <!-- Define app icon for each platform. -->
+    <!-- Define app icon for each platform. This is a relative path to config.xml.
+        For e.g. if you place an icon.png inside res folder, you should modify the
+        src in the following setting to "res/icon.png" -->
     <icon src="icon.png" />
     <icon src="res/icon/android/icon-36-ldpi.png"   gap:platform="android"    gap:qualifier="ldpi" />
     <icon src="res/icon/android/icon-48-mdpi.png"   gap:platform="android"    gap:qualifier="mdpi" />


### PR DESCRIPTION
There is a lot of confusion over what is the right way to set app icons. I myself struggled with this setting because the default icons generated by phonegap are also named "icon.png". When I placed an `icon.png` inside `img` folder, it didn't work. It's important to make it explicit in the documentation that the setting is taken relative the `config.xml` location.
